### PR TITLE
Add `removeHeaders` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Use this property to limit the matches to only those containing the given accept
 * **addHeaders** [Key Value Map Array] In the case you need to add some headers to your calls that are not present
 in the original request, you can do so by adding them here.
 
+* **removeHeaders** [Key Value Map Array] In the case you need to remove some headers from the original request, 
+you can do so by adding them here.
+
 ### Some notes
 
 Nezaldi will remove the `Host` and `Cookie` Headers of each request before sending it to the target.

--- a/server.js
+++ b/server.js
@@ -45,6 +45,9 @@ loadConf (
             } else {
                 ldebug('Match for ' + req.url);
                 req.url = match.path;
+                match.removeHeaders.forEach((h) => {
+                    if (req.headers[h]) { delete req.headers[h]; }
+                });
                 match.addHeaders.forEach((h) => {
                     req.headers[h.name] = h.value;
                 });

--- a/src/rule.js
+++ b/src/rule.js
@@ -9,6 +9,7 @@ function Rule (ruleDef) {
     this.accept = def.accept;
     this.isStatic = def.target ? !/^https?:\/\/[^\.]+\.|:.+/.test(ruleDef.target) : false
     this.addHeaders = def.addHeaders || [];
+    this.removeHeaders = def.removeHeaders || [];
 }
 
 Rule.prototype.isValid = function () { return !!this.target && !!this.regex; };
@@ -44,6 +45,7 @@ function RuleMatch (rxMatch, rule, request) {
     this.path = this.resetPath? '' : extractPath(request.url, rxMatch[0]);
     this.isStatic = rule.isStatic;
     this.addHeaders = rule.addHeaders;
+    this.removeHeaders = rule.removeHeaders;
 }
 
 function RuleCollection (ruleDefs) {


### PR DESCRIPTION
Add api for removing headers from requests which follows implementation pattern of the `addHeaders` api.  This is necessary in order to pull the navbar from the s3 bucket which services ui.e2e.apigee.net.  We previously fetched the navbar from alm-test.aeip.apigee.net, which is now dismantled.
